### PR TITLE
Feat(add-todo): Add todo implemetation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,4 +20,7 @@ def create_app(config_name):
     from app.main.auth import api as auth_blueprint
     app.register_blueprint(auth_blueprint, url_prefix="/api")
 
+    from app.main.todos import api as todos_blueprint
+    app.register_blueprint(todos_blueprint, url_prefix="/api")
+
     return app

--- a/app/db.py
+++ b/app/db.py
@@ -22,6 +22,10 @@ class Database:
         password VARCHAR(40));"
         self.cursor.execute(create_user_table)
 
+        create_todo_table = "CREATE TABLE IF NOT EXISTS todos\
+        (todo_id SERIAL PRIMARY KEY, title VARCHAR(140));"
+        self.cursor.execute(create_todo_table)
+
     def insert_user_data(self, username, password):
         """Insert user data into the database."""
         user_query = "INSERT INTO users (username, password)\
@@ -43,6 +47,12 @@ class Database:
             row = {'user_id': row[0], 'username': row[1], 'password': row[2]}
             users.append(row)
         return users
+
+    def insert_todo_data(self, title):
+        """Insert todo data into the database."""
+        todo_query = "INSERT INTO todos (title)\
+        VALUES ('{}');".format(title)
+        self.cursor.execute(todo_query)
 
     def drop_tables(self):
         """Drop tables if they exist."""

--- a/app/main/todos/__init__.py
+++ b/app/main/todos/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+api = Blueprint('todos', __name__)
+
+from app.main.todos import views

--- a/app/main/todos/todo.py
+++ b/app/main/todos/todo.py
@@ -1,0 +1,27 @@
+from flask import jsonify
+from app.models import Todo
+from app.db import Database
+
+
+db = Database()
+
+
+def create_new_todo(title):
+    """
+    This method creates a new todo.
+    parameters: title
+    returns: a json dictionary of a todo
+    """
+    todo = Todo(title=title)
+    db.insert_todo_data(title)
+    return jsonify(Todo=todo.serialize)
+
+
+def get_todo_by_title(title):
+    """
+    This method checks for the todo-list given its title.
+    parameters: title
+    returns: todo-list
+    """
+    todo = db.get_by_argument('todos', 'title', title)
+    return todo

--- a/app/main/todos/views.py
+++ b/app/main/todos/views.py
@@ -1,9 +1,11 @@
 from flask import jsonify, request
 from app.main.todos import api
 from app.main.todos.todo import create_new_todo, get_todo_by_title
+from app.main.auth.views import auth
 
 
 @api.route("/todo", methods=['POST'])
+@auth.login_required
 def add_todo():
     title = request.json.get('title')
     if title == "":

--- a/app/main/todos/views.py
+++ b/app/main/todos/views.py
@@ -1,0 +1,16 @@
+from flask import jsonify, request
+from app.main.todos import api
+from app.main.todos.todo import create_new_todo, get_todo_by_title
+
+
+@api.route("/todo", methods=['POST'])
+def add_todo():
+    title = request.json.get('title')
+    if title == "":
+        return jsonify({"message": "Fields cannot be left empty."}), 400
+    if len(title) < 10:
+        return jsonify({"message": "Title too short."}), 400
+    todo_exists = get_todo_by_title(title)
+    if todo_exists:
+        return jsonify({"message": "Todo list already exists."}), 400
+    return create_new_todo(title), 201

--- a/app/models.py
+++ b/app/models.py
@@ -12,9 +12,29 @@ class User:
     @property
     def serialize(self):
         """
-        Returns data in serializable format.
+        Returns user data in JSON serializable format.
         """
         return {
             "username": self.username,
             "password": self.password
+        }
+
+
+# Define todo-list model
+class Todo:
+    """
+    This class defines the todo list in terms
+    of the title.
+    """
+
+    def __init__(self, title):
+        self.title = title
+
+    @property
+    def serialize(self):
+        """
+        Returns todo data in JSON serializable format.
+        """
+        return {
+            "title": self.title
         }

--- a/app/tests/base.py
+++ b/app/tests/base.py
@@ -39,3 +39,15 @@ class TestBase(unittest.TestCase):
             "username": "sal ly",
             "password": "123456"
         }
+
+        self.todo1 = {
+            "title": "September List"
+        }
+
+        self.todo2 = {
+            "title": " "
+        }
+
+        self.todo3 = {
+            "title": "Sept..."
+        }

--- a/app/tests/test_todo_object.py
+++ b/app/tests/test_todo_object.py
@@ -1,0 +1,21 @@
+import unittest
+from manage import app
+from app.models import Todo
+
+
+class TestTodoObject(unittest.TestCase):
+    """
+    This class tests the todo object.
+    """
+
+    def setUp(self):
+        self.app = app.test_client()
+        self.todo1 = Todo("September List")
+
+    def test_todo_object(self):
+        """Test whether an object is an instance of the Todo class."""
+        self.assertIsInstance(self.todo1, Todo)
+
+    def test_title(self):
+        """Test title is an instance variable of the Todo class."""
+        self.assertEqual(self.todo1.title, "September List")

--- a/app/tests/test_todos.py
+++ b/app/tests/test_todos.py
@@ -1,0 +1,38 @@
+import json
+from app.tests.base import TestBase
+
+
+class TestTodosCase(TestBase):
+    """
+    This class tests the todos endpoints.
+    """
+
+    def test_create_todo(self):
+        """Test API can create a new todo."""
+        rv = self.app.post("/api/todo", data=json.dumps(self.todo1),
+                           content_type='application/json')
+        self.assertTrue(rv.status_code, 201)
+
+    def test_create_todo_with_empty_fields(self):
+        """Test API cannot create a todo with empty fields."""
+        rv = self.app.post("/api/todo", data=json.dumps(self.todo2),
+                           content_type='application/json')
+        self.assertTrue(rv.status_code, 400)
+        b"Fields cannot be left empty." in rv.data
+
+    def test_create_todo_with_short_title(self):
+        """Test API cannot create a todo with short title."""
+        rv = self.app.post("/api/todo", data=json.dumps(self.todo3),
+                           content_type='application/json')
+        self.assertTrue(rv.status_code, 400)
+        b"Title too short." in rv.data
+
+    def test_create_existing_todo(self):
+        """Test API cannot create an existing todo."""
+        rv = self.app.post("/api/todo", data=json.dumps(self.todo1),
+                           content_type='application/json')
+        self.assertTrue(rv.status_code, 201)
+        res = self.app.post("/api/todo", data=json.dumps(self.todo1),
+                            content_type='application/json')
+        self.assertTrue(res.status_code, 400)
+        b"Todo lis exists." in rv.data

--- a/app/tests/test_todos.py
+++ b/app/tests/test_todos.py
@@ -36,3 +36,7 @@ class TestTodosCase(TestBase):
                             content_type='application/json')
         self.assertTrue(res.status_code, 400)
         b"Todo lis exists." in rv.data
+
+    def test_create_todo_is_locked(self):
+        rv = self.app.get("/api/todo")
+        self.assertTrue(rv.status_code, 401)


### PR DESCRIPTION
**What does this PR do**?

A user should be able to create a todo list.

**How should it be manually tested**

- clone the repo
- ` cd ` into ` todo-list-api `
- run ` python namege.py runserver ` in your terminal
- test out the login - ` http://localhost:5000/api/login ` in postman, ` method=POST `.
- test out the protected route - ` http://localhost:5000/api/todo ` in postman ` method=POST `.

**Related stories**

[#160812463](https://www.pivotaltracker.com/story/show/160812463)