### PR TITLE
Feat(fetch-todo): Add fetch todos implementation

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -54,6 +54,15 @@ class Database:
         VALUES ('{}');".format(title)
         self.cursor.execute(todo_query)
 
+    def fetch_all_todos(self):
+        self.cursor.execute("SELECT * FROM todos")
+        rows = self.cursor.fetchall()
+        todos = []
+        for row in rows:
+            row = {'todo_id': row[0], 'title': row[1]}
+            todos.append(row)
+        return todos
+
     def drop_tables(self):
         """Drop tables if they exist."""
         query = "DROP TABLE IF EXISTS {0} CASCADE"

--- a/app/main/todos/todo.py
+++ b/app/main/todos/todo.py
@@ -17,6 +17,14 @@ def create_new_todo(title):
     return jsonify(Todo=todo.serialize)
 
 
+def get_all_todos():
+    """
+    This method returns a list of todos.
+    """
+    todos = db.fetch_all_todos()
+    return jsonify(Todos=todos)
+
+
 def get_todo_by_title(title):
     """
     This method checks for the todo-list given its title.
@@ -25,3 +33,13 @@ def get_todo_by_title(title):
     """
     todo = db.get_by_argument('todos', 'title', title)
     return todo
+
+
+def get_todo_by_id(todo_id):
+    """
+    This method checks for the todo-list given its id.
+    parameters: todo_id
+    returns: todo-list
+    """
+    todo = db.get_by_argument('todos', 'todo_id', todo_id)
+    return jsonify(Todo={'todo_id': todo[0], 'title': todo[1]})

--- a/app/main/todos/views.py
+++ b/app/main/todos/views.py
@@ -1,6 +1,7 @@
 from flask import jsonify, request
 from app.main.todos import api
-from app.main.todos.todo import create_new_todo, get_todo_by_title
+from app.main.todos.todo import (create_new_todo, get_todo_by_title,
+                                 get_all_todos, get_todo_by_id)
 from app.main.auth.views import auth
 
 
@@ -16,3 +17,15 @@ def add_todo():
     if todo_exists:
         return jsonify({"message": "Todo list already exists."}), 400
     return create_new_todo(title), 201
+
+
+@api.route("/todo", methods=['GET'])
+@auth.login_required
+def get_todos():
+    return get_all_todos(), 200
+
+
+@api.route("/todo/<int:todo_id>", methods=['GET'])
+@auth.login_required
+def get_todo(todo_id):
+    return get_todo_by_id(todo_id), 200

--- a/app/tests/test_todos.py
+++ b/app/tests/test_todos.py
@@ -38,5 +38,18 @@ class TestTodosCase(TestBase):
         b"Todo lis exists." in rv.data
 
     def test_create_todo_is_locked(self):
+        """Tets create todo resource requires auth."""
         rv = self.app.get("/api/todo")
         self.assertTrue(rv.status_code, 401)
+
+    def test_get_all_todos(self):
+        """Test API can return a list of todos."""
+        rv = self.app.get("api/todo", data=json.dumps(self.todo1),
+                          content_type='application/json')
+        self.assertTrue(rv.status_code, 200)
+
+    def test_get_a_todo(self):
+        """Test API can return a todo list."""
+        rv = self.app.get("api/todo/1", data=json.dumps(self.todo1),
+                          content_type='application/json')
+        self.assertTrue(rv.status_code, 200)


### PR DESCRIPTION
**What does this PR do**?

Adds a fetch for all tods and a single todo given its id.

**How should it be manually tested**

- clone the repo
- ` cd ` into ` todo-list-api `
- run ` python namege.py runserver ` in your terminal
- test out the login - ` http://localhost:5000/api/login ` in postman, ` method=POST `.
- test out the protected route - ` http://localhost:5000/api/todo ` in postman ` method=GET `.
- test out the protected route - ` http://localhost:5000/api/todo/<todo-id> ` in postman ` method=GET `.

**Related stories**

[#160961683](https://www.pivotaltracker.com/story/show/160961683)